### PR TITLE
add `composer build` command to match README

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -25,6 +25,7 @@
     "monolog/monolog": "Sends your logs to files, sockets, inboxes, databases and various web services."
   },
   "scripts": {
+    "build": "composer lint:syntax && composer lint:style && composer test:units && composer test:mutations",
     "lint:beautify": "vendor/bin/phpcbf --standard=PSR2 --extensions=php --severity=1 src/ tests/ -v",
     "lint:style": "vendor/bin/phpcs --standard=PSR2 --extensions=php --severity=1 src/ tests/ -v",
     "lint:syntax": "vendor/bin/parallel-lint src/ tests/",


### PR DESCRIPTION
add `composer build` command to match documentation. it is a wrapper of other composer commands to lint and test.